### PR TITLE
Add initial zypper support

### DIFF
--- a/pkm
+++ b/pkm
@@ -20,11 +20,11 @@ opers=(
     'Query'
     'Install'
     'Delete'
+    'Update'
     'List Installed'
 )
 
 init_term
-_update
 _draw "${opers[@]}"
 
 for((;;)) {
@@ -37,7 +37,8 @@ for((;;)) {
             "${opers[1]}") _query;;
             "${opers[2]}") _install;;
             "${opers[3]}") _delete;;
-            "${opers[4]}") list_installed;;
+            "${opers[4]}") _update;;
+            "${opers[5]}") list_installed;;
         esac
         
         _draw "${opers[@]}"

--- a/pkm
+++ b/pkm
@@ -11,6 +11,8 @@ elif hash apt; then
     . ./src/apt.sh
 elif hash dnf; then
     . ./src/dnf.sh
+elif hash zypper; then
+    . ./src/zypper.sh
 fi
 
 opers=(

--- a/src/zypper.sh
+++ b/src/zypper.sh
@@ -1,0 +1,108 @@
+#!/bin/bash
+
+_zypper() {
+    printf '\e[2J\e[H\e[?25h'
+
+    if (( $3 )); then
+        sudo zypper "$1" "$2"
+    else
+        zypper "$1" "$2"
+    fi
+
+    printf '\e[?25l'
+}
+
+list_installed() {
+    local installed installedInit
+    
+    mapfile -t installed < <(zypper search -i)
+    installedInit=("${installed[@]}")
+    
+    printf '\e[2J'
+
+    _draw "${installed[@]}"
+
+    for((;;)) {
+        _ibar '[<] back [>] delete'
+        hover_interface installed "${installedInit[@]}"
+
+        case $REPLY in
+            '[D'|[hHaA]) return 1;;
+            ''|'[C'|[lLdD])
+                _delete "${installed[cursor-LINES]}"
+                _draw "${installed[@]}"
+            ;;
+        esac
+    }
+}
+
+_delete() {
+    [[ $1 ]]|| _ibar 'Delete: ' pkg
+    _zypper remove "${1:-$pkg}" 1
+    base_keymap
+}
+
+_install() {
+    local pkg
+
+    [[ $1 ]] || _ibar 'Install: ' pkg
+    _zypper install "${1:-$pkg}" 1
+    base_keymap
+    _draw "${queries[@]-}"
+}
+
+
+_info() {
+    local pkg
+
+    [[ $1 ]] || _ibar 'Info: ' pkg
+    _zypper info "${1:-$pkg}"
+    base_keymap
+}
+
+_query() {
+    local pkg queries queriesInit
+
+    _ibar 'Query: ' pkg
+    [[ $pkg ]] || return
+    
+    mapfile -t queries < <(zypper search -i "${1:-$pkg}")
+    queriesInit=("${queries[@]}")
+    
+    printf '\e[2J'
+
+    _draw "${queries[@]}"
+
+    for((;;)) {
+        _ibar '[<] back [>] delete'
+        hover_interface queries "${queriesInit[@]}"
+
+        case $REPLY in
+            '[D'|[hHaA]) return 1;;
+            ''|'[C'|[lLdD])
+                _delete "${queries[cursor-LINES]%% -*}"
+                _draw "${queries[@]}"
+            ;;
+        esac
+    }
+}
+
+_update() {
+    printf '\e[?25h'
+
+    ARGU=up
+
+    if grep tumbleweed /etc/os-release > /dev/null 2>&1; then
+        ARGU=dup
+    fi
+
+    for _ in $ARGU; do sudo zypper "$_" --no-allow-vendor-change; done
+
+    printf '\e[?25l'
+
+    for((;;)) {
+        _ibar '[*] continue' ''; read -rn1
+        
+        return
+    }
+}

--- a/src/zypper.sh
+++ b/src/zypper.sh
@@ -15,7 +15,11 @@ _zypper() {
 list_installed() {
     local installed installedInit
     
+<<<<<<< Updated upstream
     mapfile -t installed < <(zypper search -i)
+=======
+    mapfile -t installed < <(zypper search -i | awk '{print $3}')
+>>>>>>> Stashed changes
     installedInit=("${installed[@]}")
     
     printf '\e[2J'


### PR DESCRIPTION
Adds initial zypper support for openSUSE Leap and Tumbleweed. Tested on both openSUSE Leap and Tumbleweed, and re-tested on both apt and dnf systems. Might need minor tweaks, but just adds initial support.